### PR TITLE
Add image file to analyzer api request

### DIFF
--- a/app/assets/javascripts/move_on.js
+++ b/app/assets/javascripts/move_on.js
@@ -4,16 +4,22 @@ $( document ).ready(function() {
     console.log(pathname);
     var url = document.URL.split("/")
     var id = url[url.length - 1]
+    var image_url = $("#dog-image").attr("src")
 
-    $.getJSON("https://paws-api.herokuapp.com/api/v1/dog_image_categories",
+    //getJSON("http://162.243.13.94:8080/api/v1/dog_image_categories",
+    $.getJSON("http://localhost:5000/api/v1/dog_image_categories",
+      {image: image_url},
       function(result){
-        console.log(result["breed"])
-        console.log("Sending that post request")
+        console.log(result["breed"]);
+        console.log("Sending that post request");
         $.ajax({ url: "/dog_images/"+id,
                  type: 'PUT',
-                 data: "breed="+result["breed"]})
-        console.log('Load was performed.');
-        window.location.replace('/dog_images/'+id+'/analysis');
+                 data: "breed="+result["breed"],
+                 complete: function(data){
+                   console.log('Load was performed.');
+                   window.location.replace('/dog_images/'+id+'/analysis');
+                 }
+               })
       });
   }
 })

--- a/app/models/dog_image.rb
+++ b/app/models/dog_image.rb
@@ -5,7 +5,7 @@ class DogImage < ActiveRecord::Base
 
   has_attached_file :image, path: "dog_images/image-:id.:extension"
   validates :image, attachment_presence: true
-  validates_with AttachmentSizeValidator, attributes: :image, less_than: 2.megabytes
+  validates_with AttachmentSizeValidator, attributes: :image, less_than: 3.megabytes
   validates_attachment_content_type :image, content_type: /\Aimage\/.*\Z/
 
 end

--- a/app/views/dog_images/show.html.haml
+++ b/app/views/dog_images/show.html.haml
@@ -4,4 +4,5 @@
       %h2.text-center Fetching those doggie details ...
       =image_tag @doggie.image,
                  class: "img-responsive center-block bottom-padding-20",
-                 alt: "dog placeholder"
+                 alt: "dog placeholder",
+                 id: "dog-image"


### PR DESCRIPTION
- AJAX request is only valid if you have paws-api running on localhost:5000
- increases accepted image size to 3 MB
